### PR TITLE
[SCRUM-264] Refactor auth store to store API user object as well as authToken

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -50,20 +50,16 @@ export default {
       axios.defaults.baseURL = config.apiUrl
       axios.defaults.headers.common['Content-Type'] = 'application/json'
 
-      // TODO: Need to test this by expiring the auth token on the server
-      const authErrorHandler = (response) => {
-        if ((response.error && response.error.status === 401) ||
-        response.status === 401) {
-          this.$store.commit('clearUserState')
+      const authErrorHandler = (error) => {
+        if (error.response && error.response.status === 401) {
+          this.$store.dispatch('logout', this.$router)
         }
 
-        return response
+        return Promise.reject(error)
       }
 
-      // TODO: If this route is authenticated we'll want to send the user
-      //  to the /login endpoint
       axios.interceptors.response.use(
-        authErrorHandler,
+        (response) => { return response }, // NOTE: use a no-op here since we're only interested in intercepting errors
         authErrorHandler
       )
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -22,18 +22,21 @@ export default {
     MetaMaskModal,
   },
   created() {
+    this.initializeApi()
+
     this.$store.dispatch('registerWeb3', this.$router)
       .then(() => {
         if (this.authToken) {
-          this.$store.dispatch('updateUserState')
+          this.$store.dispatch('updateUserState', this.authToken)
         }
       })
-
-    this.initializeApi()
   },
   computed: {
+    user() {
+      return this.$store.state.auth.user
+    },
     authToken() {
-      return this.$store.state.auth.token
+      return this.$store.state.auth.authToken
     },
     recordId() {
       return this.$route.params.recordId


### PR DESCRIPTION
This is probably overkill now that I think about it, but this PR adds the API user object to the auth store. The user object is requested as soon as `authToken` is set in the store. At this point, the API user object is really only necessary to read the `canRequestFaucetTokens ` / `faucetLastRequestedAt` variables for the manage tokens page.

This PR also fixes response interceptor logic so that 401 errors log the user out.