### PR TITLE
Improved MetaMask Login UX

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,9 @@ export default {
     web3() {
       return this.$store.state.web3
     },
+    web3Error() {
+      return this.$store.state.web3.error
+    },
   },
   methods: {
     initializeApi() {
@@ -76,6 +79,13 @@ export default {
           return true
         default:
           return false
+      }
+    },
+  },
+  watch: {
+    web3Error(error) {
+      if (error) {
+        this.$store.dispatch('logout', this.$router)
       }
     },
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,9 @@
 <template>
   <div id="app">
     <app-side-bar v-if="authToken" />
-    <div class="main-content" :class="{ 'with-background': this.$route.name === 'login' }">
+    <div class="main-content" :class="{ 'with-background': this.useBackground() }">
       <router-view />
     </div>
-    <meta-mask-modal />
     <toast-container />
   </div>
 </template>
@@ -15,7 +14,6 @@ import axios from 'axios'
 import { apiUrl } from './util/config'
 import AppSideBar from './components/AppSideBar'
 import ToastContainer from './components/ToastContainer'
-import MetaMaskModal from './components/modals/MetaMaskModal'
 
 import analytics from './util/analytics' // eslint-disable-line no-unused-vars
 
@@ -23,7 +21,6 @@ export default {
   name: 'App',
   components: {
     AppSideBar,
-    MetaMaskModal,
     ToastContainer,
   },
   created() {
@@ -71,6 +68,15 @@ export default {
         (response) => { return response }, // NOTE: use a no-op here since we're only interested in intercepting errors
         authErrorHandler
       )
+    },
+    useBackground() {
+      switch (this.$route.name) {
+        case 'login':
+        case 'home':
+          return true
+        default:
+          return false
+      }
     },
   },
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import Router from 'vue-router'
 
 import store from '../store'
 
+import HomeView from '../views/HomeView'
 import LoginView from '../views/LoginView'
 import FeatureListView from '../views/FeatureListView'
 import TransferListView from '../views/TransferListView'
@@ -25,7 +26,8 @@ const ifNotAuthenticated = (to, from, next) => {
 
 const router = new Router({
   routes: [
-    { name: 'login', path: '/login', component: LoginView, beforeEnter: ifNotAuthenticated, meta: { allowUnauthenticatedUsers: true } },
+    { name: 'home', path: '/', component: HomeView, beforeEnter: ifNotAuthenticated, meta: { allowUnauthenticatedUsers: true } },
+    { name: 'login', path: '/login', component: LoginView, meta: { allowUnauthenticatedUsers: true } },
     { name: 'transfers', path: '/transfers', redirect: '/transfers/incoming' },
     { name: 'incoming-transfers', path: '/transfers/incoming', component: TransferListView, props: { transferDirection: 'incoming' } },
     { name: 'outgoing-transfers', path: '/transfers/outgoing', component: TransferListView, props: { transferDirection: 'outgoing' } },
@@ -34,7 +36,6 @@ const router = new Router({
     { name: 'collection', path: '/collection', component: RecordListView },
     { name: 'manage-tokens', path: '/manage-tokens', component: ManageTokensView },
     { name: 'record-detail', path: '/record/:recordId', component: RecordDetailView, meta: { allowUnauthenticatedUsers: true } },
-    { path: '/', redirect: '/collection' },
   ],
 })
 

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -152,7 +152,7 @@ const actions = {
   logout({ commit }, router) {
     commit('clearUserState')
 
-    router.replace('/login')
+    router.replace('/')
   },
 }
 

--- a/src/util/analytics/eventNames.js
+++ b/src/util/analytics/eventNames.js
@@ -1,8 +1,16 @@
+// IMPORTANT: Do not change the values. These are used for analytics tracking and need
+//  to stay consistent
+
 export default {
+  'events:viewer:view-home-page': 'View Home Page',
+  'events:click-home-login': 'Click Homepage Login Button',
+  'events:click-about-codex': 'Click About Codex',
+
   'events:viewer:view-login-page': 'View Login Page',
   'events:click-login-button': 'Click Login Button',
+  'events:click-install-metamask': 'Click Install MetaMask',
+  'events:click-check-metamask': 'Click Check MetaMask',
   'events:login': 'Login',
-  'events:click-about-codex': 'Click About Codex',
   'events:click-logout-button': 'Click Logout Button',
 
   'events:view-collection-page': 'View Collection Page',

--- a/src/util/analytics/events.js
+++ b/src/util/analytics/events.js
@@ -17,11 +17,17 @@ const events = (analytics) => {
     })
   }
 
+  // Home
+  registerEvent('events:viewer:view-home-page')
+  registerEvent('events:click-home-login')
+  registerEvent('events:click-about-codex')
+
   // Login
   registerEvent('events:viewer:view-login-page')
   registerEvent('events:click-login-button')
+  registerEvent('events:click-install-metamask')
+  registerEvent('events:click-check-metamask')
   registerEvent('events:login')
-  registerEvent('events:click-about-codex')
   registerEvent('events:click-logout-button')
 
   // Collection

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-7">
+        <div class="logo"><b-link href="/#/"><img src="../assets/logos/codex/gold.svg" /></b-link></div>
+        <h1>Codex Viewer</h1>
+        <div class="lead">Decentralized application for viewing The Codex Registry</div>
+        <b-button variant="primary" @click="login">Login</b-button>
+        <b-button variant="outline-primary" @click="aboutCodex">About Codex</b-button>
+      </div>
+      <div class="col-sm-5 secondary">
+        <div class="bust"><img src="../assets/images/bust.png" /></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import EventBus from '../util/eventBus'
+
+export default {
+  name: 'home-view',
+  methods: {
+    login() {
+      EventBus.$emit('events:click-home-login')
+      window.location = '/#/login'
+    },
+    aboutCodex() {
+      EventBus.$emit('events:click-about-codex')
+      window.location = 'https://www.codexprotocol.com'
+    },
+  },
+  created() {
+    EventBus.$emit('events:viewer:view-home-page')
+  },
+}
+</script>
+
+<style lang="stylus" scoped>
+
+  .container
+    display: flex
+    align-items: center
+    height: 100%
+
+  .row
+    width: 100%
+
+  .secondary
+    text-align: right
+
+  .logo
+    max-width: 100px
+    margin-bottom: 2.5rem
+
+  h1
+    font-family: $font-family-serif
+    font-weight: bold
+    font-size: 3rem
+
+  .lead
+    font-weight: 400
+    font-size: 1.25rem
+    margin-bottom: 3.125rem
+
+  .btn-primary
+    margin-right: 1rem
+
+</style>


### PR DESCRIPTION
This PR removes the use of `MetaMaskModal` to determine if a user is connected to MetaMask.

We now detect that on the `/login` page and guide users through each step:
* Install MetaMask extension
* Connect to correct network
* Unlock MetaMask account
* Logout user if MetaMask becomes locked