### PR TITLE
Fix off-center login art that was overflowing it's container

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div class="row">
-      <div class="col-sm-7">
+      <div class="col-sm-5">
         <div class="logo"><b-link href="/#/"><img src="../assets/logos/codex/gold.svg" /></b-link></div>
         <h1>Codex Viewer (Beta)</h1>
         <div class="lead">Decentralized application for viewing The Codex Registry</div>
@@ -11,8 +11,8 @@
         </div>
         <bug-bounty-marketing-card v-if="showBugBountyMarketingCard" />
       </div>
-      <div class="col-sm-5 secondary">
-        <div class="bust"><img src="../assets/images/login-art.png" /></div>
+      <div class="col-sm-7 secondary">
+        <div class="login-art"><img src="../assets/images/login-art.png" /></div>
       </div>
     </div>
   </div>
@@ -52,15 +52,16 @@ export default {
 <style lang="stylus" scoped>
 
   .container
+    height: 100%
     display: flex
     align-items: center
-    height: 100%
 
   .row
     width: 100%
 
   .secondary
     text-align: right
+    align-self: center
 
   .logo
     max-width: 100px
@@ -85,4 +86,7 @@ export default {
 
     button
       width: 50%
+
+  .login-art img
+    width: 100%
 </style>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <div class="row">
-      <div class="col-sm-7">
+      <div class="col-sm-5">
         <div class="logo"><b-link href="/#/"><img src="../assets/logos/codex/gold.svg" /></b-link></div>
         <h1 v-html="pageContent.title"></h1>
         <div class="lead" v-html="pageContent.description"></div>
@@ -13,8 +13,8 @@
           {{ buttonTitle }}
         </b-button>
       </div>
-      <div class="col-sm-5 secondary">
-        <div class="bust"><img src="../assets/images/login-art.png" /></div>
+      <div class="col-sm-7 secondary">
+        <div class="login-art"><img src="../assets/images/login-art.png" /></div>
       </div>
     </div>
   </div>
@@ -144,15 +144,16 @@ export default {
 <style lang="stylus" scoped>
 
   .container
+    height: 100%
     display: flex
     align-items: center
-    height: 100%
 
   .row
     width: 100%
 
   .secondary
     text-align: right
+    align-self: center
 
   .logo
     max-width: 100px
@@ -170,5 +171,8 @@ export default {
 
   .btn-primary
     width: calc(50% - 0.5rem)
+
+  .login-art img
+    width: 100%
 
 </style>


### PR DESCRIPTION
The new login art was overflowing it's container and making the page look unbalanced and weird. This PR tweaks the layout a little bit to bring the image inside it's container and center everything a bit better.

![screen shot 2018-06-21 at 6 19 55 pm](https://user-images.githubusercontent.com/2358694/41792103-554d788a-761d-11e8-9ec5-98ec96c0cd5e.png)