### PR TITLE
Mobile pages: Gallery, Settings

### DIFF
--- a/src/components/GalleryListItem.vue
+++ b/src/components/GalleryListItem.vue
@@ -1,29 +1,30 @@
 <template>
-  <div class="gallery-card" v-if="gallery.codexRecords">
-    <b-card @click.prevent="viewGallery">
-      <b-carousel
-        slot="header"
-        :interval="3000"
-        class="fixed-size-carousel"
-      >
-        <b-carousel-slide
-          :key="codexRecord.id"
-          v-for="codexRecord in gallery.codexRecords"
-          :img-src="codexRecord.metadata.mainImage ? codexRecord.metadata.mainImage.uri : missingImage"
-        ></b-carousel-slide>
-      </b-carousel>
-      <div class="card-text">
-        <p>
-          <a href="#" @click.prevent="viewGallery">
-            {{ gallery.name }}
-          </a>
-        </p>
-        <small class="text-muted">
-          {{ gallery.description }}
-        </small>
-      </div>
-    </b-card>
-  </div>
+  <b-card
+    v-if="gallery.codexRecords"
+    @click.prevent="viewGallery"
+  >
+    <b-carousel
+      slot="header"
+      :interval="3000"
+      class="fixed-size-carousel"
+    >
+      <b-carousel-slide
+        :key="codexRecord.id"
+        v-for="codexRecord in gallery.codexRecords"
+        :img-src="codexRecord.metadata.mainImage ? codexRecord.metadata.mainImage.uri : missingImage"
+      ></b-carousel-slide>
+    </b-carousel>
+    <div class="card-text">
+      <p>
+        <a href="#" @click.prevent="viewGallery">
+          {{ gallery.name }}
+        </a>
+      </p>
+      <small class="text-muted">
+        {{ gallery.description }}
+      </small>
+    </div>
+  </b-card>
 </template>
 
 <script>
@@ -50,18 +51,30 @@ export default {
 <style lang="stylus" scoped>
 @import "../assets/variables.styl"
 
-.gallery-card
-  width: 25%
-  margin-bottom: 2em
+.card
+  flex: none
+  min-width: 180px
+  border: none
+  cursor: pointer
+  margin-bottom: 1rem
+  margin-top: 1rem
+  border-radius: 0 0 .25rem .25rem
+  background-color: #fff
 
-  .card
-    border: none
-    cursor: pointer
-    border-radius: 0 0 .25rem .25rem
+  @media screen and (min-width: $breakpoint-sm)
+    max-width: calc((100% * 1/2) - 2rem)
+
+  @media screen and (min-width: $breakpoint-md)
+    max-width: calc((100% * 1/3) - 2rem)
+
+  @media screen and (min-width: $breakpoint-lg)
+    max-width: calc((100% * 1/4) - 2rem)
+
+  @media screen and (min-width: $breakpoint-xl)
+    max-width: calc((100% * 1/5) - 2rem)
 
   .card-header
     padding: 0
-    height: 25vh
 
   .card-body
     a

--- a/src/components/PersonalStakesTable.vue
+++ b/src/components/PersonalStakesTable.vue
@@ -28,7 +28,7 @@
         :style="{ order: index }"
         :key="'stakedFor' + index"
       >
-        {{ property }}
+        <hash-formatter :data="property" />
       </div>
 
       <div class="table-header">Unlock date</div>
@@ -45,10 +45,15 @@
 
 <script>
 import formatTokenAmount from '../util/formatTokenAmount'
+import HashFormatter from './HashFormatter'
+
 
 export default {
   name: 'personal-stakes-table',
   props: ['personalStakes'],
+  components: {
+    HashFormatter,
+  },
   methods: {
     formatTokenAmount(rawAmount) {
       return formatTokenAmount(rawAmount)

--- a/src/views/GalleryListView.vue
+++ b/src/views/GalleryListView.vue
@@ -1,31 +1,35 @@
 <template>
-  <div>
-    <app-header title="Galleries" />
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <app-header title="Galleries" />
 
-    <div v-if="galleries.length">
-      <b-card-group deck>
-        <gallery-list-item
-          v-if="gallery.codexRecords"
-          v-for="gallery in galleries"
-          :gallery="gallery"
-          :key="gallery.id"
-        />
-        <b-card
-          title="Coming Soon"
-          class="upsell-card"
-        >
-          <p class="card-text">
-            Create your own public galleries!
-          </p>
-          <p class="card-text">
-            Soon you will be able to organize your Collection into public galleries so you can share groups of Codex Records like the one you see here.
-          </p>
-        </b-card>
-      </b-card-group>
-    </div>
+        <div v-if="galleries.length">
+          <b-card-group deck>
+            <gallery-list-item
+              v-if="gallery.codexRecords"
+              v-for="gallery in galleries"
+              :gallery="gallery"
+              :key="gallery.id"
+            />
+            <b-card
+              title="Coming Soon"
+              class="upsell-card"
+            >
+              <p class="card-text">
+                Create your own public galleries!
+              </p>
+              <p class="card-text">
+                Soon you will be able to organize your Collection into public galleries so you can share groups of Codex Records like the one you see here.
+              </p>
+            </b-card>
+          </b-card-group>
+        </div>
 
-    <div v-else>
-      No galleries have been created yet.
+        <div v-else>
+          No galleries have been created yet.
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -70,17 +74,25 @@ export default {
 
 @import "../assets/variables.styl"
 
-.upsell-card
+.card
   flex: none
-  width: 25%
-  text-align: center
-  margin-bottom: 2em
-  background: transparent
-  border: 1px solid $color-light
+  min-width: 180px
+  border: none
+  margin-bottom: 1rem
+  margin-top: 1rem
+  border-radius: 0 0 .25rem .25rem
+  background-color: rgba(white, .1)
 
-  > div
-    display: flex
-    flex-direction: column
-    justify-content: center
+  @media screen and (min-width: $breakpoint-sm)
+    max-width: calc((100% * 1/2) - 2rem)
+
+  @media screen and (min-width: $breakpoint-md)
+    max-width: calc((100% * 1/3) - 2rem)
+
+  @media screen and (min-width: $breakpoint-lg)
+    max-width: calc((100% * 1/4) - 2rem)
+
+  @media screen and (min-width: $breakpoint-xl)
+    max-width: calc((100% * 1/5) - 2rem)
 
 </style>

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -1,41 +1,47 @@
 <template>
-  <div v-if="gallery">
-    <app-header :hide-network-details="true" :title="gallery.name">
-      <b-button variant="outline-primary" @click="viewFullscreen" v-if="browserSupportsFullscreen">
-        View Fullscreen
-      </b-button>
-    </app-header>
+  <div
+    v-if="gallery"
+    class="container-fluid"
+  >
+    <div class="row">
+      <div class="col-12">
+        <app-header :hide-network-details="true" :title="gallery.name">
+          <b-button variant="outline-primary" @click="viewFullscreen" v-if="browserSupportsFullscreen">
+            View Fullscreen
+          </b-button>
+        </app-header>
 
-    <div class="carousel-container" ref="carousel-container">
-      <b-carousel
-        controls
-        slot="header"
-        v-model="slideIndex"
-        class="fixed-size-carousel"
-        :interval="gallery.slideDuration"
-      >
-        <b-carousel-slide
-          :key="codexRecord.id"
-          v-for="codexRecord in gallery.codexRecords"
-          :img-src="codexRecord.metadata.mainImage ? codexRecord.metadata.mainImage.uri : missingImage"
-        ></b-carousel-slide>
-      </b-carousel>
+        <div class="carousel-container" ref="carousel-container">
+          <b-carousel
+            controls
+            slot="header"
+            v-model="slideIndex"
+            class="fixed-size-carousel"
+            :interval="gallery.slideDuration"
+          >
+            <b-carousel-slide
+              :key="codexRecord.id"
+              v-for="codexRecord in gallery.codexRecords"
+              :img-src="codexRecord.metadata.mainImage ? codexRecord.metadata.mainImage.uri : missingImage"
+            ></b-carousel-slide>
+          </b-carousel>
 
-      <p class="record-info">
-        <a href="#" @click.prevent="viewRecord(currentCodexRecord.tokenId)">
-          {{ currentCodexRecord.metadata.name }}
-        </a>
-      </p>
+          <p class="record-info">
+            <a href="#" @click.prevent="viewRecord(currentCodexRecord.tokenId)">
+              {{ currentCodexRecord.metadata.name }}
+            </a>
+          </p>
+        </div>
+
+        <b-card-group deck class="record-list">
+          <record-list-item
+            v-for="record in gallery.codexRecords"
+            :codex-record="record"
+            :key="record.tokenId"
+          />
+        </b-card-group>
+      </div>
     </div>
-
-    <b-card-group deck class="record-list">
-      <record-list-item
-        v-for="record in gallery.codexRecords"
-        :codex-record="record"
-        :key="record.tokenId"
-      />
-    </b-card-group>
-
   </div>
 </template>
 
@@ -102,8 +108,6 @@ export default {
 // a lot of these .carousel-container styles are mainly here for the fullscreen
 //  view
 .carousel-container
-  width: 100%
-  height: 100%
   display: flex
   align-items: center
   flex-direction: column

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -111,9 +111,12 @@ export default {
   background-color: $color-dark
 
 .carousel
-  width: 50%
-  height: 50vh
-  max-width: 50%
+  padding: 1rem
+
+  @media screen and (min-width: $breakpoint-md)
+    width: 50%
+    height: 50vh
+    max-width: 50%
 
 .record-info
   width: 50%
@@ -124,8 +127,12 @@ export default {
   background-color: rgba(white, .01)
 
 .record-list
-  display: flex
-  flex-wrap: wrap
+  display: none
   margin-top:  4rem
+  padding: 1rem
+
+  @media screen and (min-width: $breakpoint-md)
+    display: flex
+    flex-wrap: wrap
 
 </style>

--- a/src/views/ManageTokensView.vue
+++ b/src/views/ManageTokensView.vue
@@ -1,46 +1,51 @@
 <template>
-  <div>
-    <app-header title="Manage Tokens" />
-    <h5 class="mb-5">Get CODX from the faucet &amp; stake CODX for discounts!</h5>
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <app-header title="Manage Tokens" />
+        <h5 class="mb-5">Get CODX from the faucet &amp; stake CODX for discounts!</h5>
 
-    <div class="item">
-      <p>Registry contract approved? {{ registryContractApproved ? 'Yes!' : 'No' }}</p>
-      <b-button variant="primary" v-b-modal.approveRegistryModal :disabled="registryContractApproved">
-        Approve the registry contract
-      </b-button>
+        <div class="item contract">
+          <p>Registry contract approved? {{ registryContractApproved ? 'Yes!' : 'No' }}</p>
+          <b-button variant="primary" v-b-modal.approveRegistryModal :disabled="registryContractApproved">
+            Approve the registry contract
+          </b-button>
+        </div>
+
+        <div class="item contract">
+          <p>Stake contract approved? {{ stakeContractApproved ? 'Yes!' : 'No' }}</p>
+          <b-button variant="primary" v-b-modal.approveStakeModal :disabled="stakeContractApproved">
+            Approve the staking contract
+          </b-button>
+        </div>
+
+        <div class="item">
+          <p v-if="!stakeContractApproved">Before you can stake CODX, you have to approve the contract above</p>
+
+          <personal-stakes-table :personal-stakes="userState.personalStakes" />
+          <div class="stake-buttons">
+            <b-button variant="primary" v-b-modal.stakeTokensModal :disabled="!stakeContractApproved">
+              Stake more CODX
+            </b-button>
+            <b-button variant="outline-primary" v-b-modal.unstakeTokensModal :disabled="!stakeContractApproved">
+              Unstake CODX
+            </b-button>
+            <b-button variant="outline-primary">Collect interest</b-button>
+          </div>
+        </div>
+
+        <approve-contract-modal id="approveRegistryModal" :contractInstance="recordContract" stateProperty="registryContractApproved">
+          This will grant the Codex Viewer permission to spend CODX on your behalf.
+        </approve-contract-modal>
+
+        <approve-contract-modal id="approveStakeModal" :contractInstance="stakeContract" stateProperty="stakeContractApproved">
+          This will allow you to stake CODX.
+        </approve-contract-modal>
+
+        <stake-tokens-modal />
+        <unstake-tokens-modal :unstake="true" />
+      </div>
     </div>
-
-    <div class="item">
-      <p>Stake contract approved? {{ stakeContractApproved ? 'Yes!' : 'No' }}</p>
-      <b-button variant="primary" v-b-modal.approveStakeModal :disabled="stakeContractApproved">
-        Approve the staking contract
-      </b-button>
-    </div>
-
-    <div class="item">
-      <p v-if="!stakeContractApproved">Before you can stake CODX, you have to approve the contract above</p>
-
-      <personal-stakes-table :personal-stakes="userState.personalStakes" />
-
-      <b-button class="mr-3" variant="primary" v-b-modal.stakeTokensModal :disabled="!stakeContractApproved">
-        Stake more CODX
-      </b-button>
-      <b-button class="mr-3" variant="outline-primary" v-b-modal.unstakeTokensModal :disabled="!stakeContractApproved">
-        Unstake CODX
-      </b-button>
-      <b-button variant="outline-primary">Collect interest</b-button>
-    </div>
-
-    <approve-contract-modal id="approveRegistryModal" :contractInstance="recordContract" stateProperty="registryContractApproved">
-      This will grant the Codex Viewer permission to spend CODX on your behalf.
-    </approve-contract-modal>
-
-    <approve-contract-modal id="approveStakeModal" :contractInstance="stakeContract" stateProperty="stakeContractApproved">
-      This will allow you to stake CODX.
-    </approve-contract-modal>
-
-    <stake-tokens-modal />
-    <unstake-tokens-modal :unstake="true" />
   </div>
 </template>
 
@@ -89,6 +94,25 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
-  .item
-    margin-bottom: 4rem
+
+@import "../assets/variables.styl"
+
+.item
+  margin-bottom: 4rem
+
+.contract button
+  white-space: normal
+
+.stake-buttons
+  display: flex
+  flex-direction: column
+
+  button
+    margin-bottom: 1rem
+
+  @media screen and (min-width: 675px)
+    flex-direction: row
+
+    button
+      margin-right: 1rem
 </style>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,24 +1,28 @@
 <template>
-  <div>
-    <app-header title="Settings &amp; Privacy" />
-    <div class="record-list" v-if="records.length">
-      <b-container class="record-settings-row">
-        <b-row>
-          <b-col class="image">Image</b-col>
-          <b-col class="name">Asset Name</b-col>
-          <b-col class="toggle" v-if="user && user.isGalleryEnabled">Include in Gallery</b-col>
-          <b-col class="toggle">Details Public</b-col>
-        </b-row>
-      </b-container>
-      <!-- TODO: Better handling of record w/ no metadata -->
-      <record-privacy-settings-row-item v-for="record in records"
-        v-if="record.metadata"
-        :codex-record="record"
-        :key="record.tokenId"
-      />
-    </div>
-    <div v-else>
-      You have no Records in your collection!
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <app-header title="Settings &amp; Privacy" />
+        <div class="record-list" v-if="records.length">
+          <b-container class="record-settings-row">
+            <b-row>
+              <b-col class="image">Image</b-col>
+              <b-col class="name">Asset Name</b-col>
+              <b-col class="toggle" v-if="user && user.isGalleryEnabled">Include in Gallery</b-col>
+              <b-col class="toggle">Details Public</b-col>
+            </b-row>
+          </b-container>
+          <!-- TODO: Better handling of record w/ no metadata -->
+          <record-privacy-settings-row-item v-for="record in records"
+            v-if="record.metadata"
+            :codex-record="record"
+            :key="record.tokenId"
+          />
+        </div>
+        <div v-else>
+          You have no Records in your collection!
+        </div>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Most of the work here is making the Gallery mobile friendly.

On small screens we are only showing the carousel (we hide the tiles below).

The Settings page has also been updated, though it will break on the smallest of screens if the user has the ability to add an item to the Gallery.

A few markup changes were also made to the Manage Tokens page to make it more mobile friendly. We won't put in more work here as this page will be revamped soon.