### PR TITLE
Add "Copy Share Link" Buttons to RecordDetailView and GalleryView

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -151,11 +151,12 @@ body
   font-family: $font-family-sans-serif
 
 #app
-  display: flex
   width: 100%
+  display: flex
+  background-color: $color-dark
 
   &.with-background
-    background: url(assets/images/pattern-dark.jpeg)
+    background-image: url(assets/images/pattern-dark.jpeg)
 
 .main-content-wrapper
   display: flex

--- a/src/util/copyToClipboard.js
+++ b/src/util/copyToClipboard.js
@@ -1,0 +1,41 @@
+// this method sets the user's clipboard to the specified text via these steps:
+//
+//  1. create an "invisible" textarea
+//  2. set it's value to the specified text
+//  3. inject it into the DOM
+//  4. select the entire contents
+//  5. copy the contents to the clipboard
+//  6. remove it from the DOM
+
+import EventBus from './eventBus'
+
+export default (text, toastMessage = 'Text copied to clipboard!') => {
+
+  if (!document.execCommand) {
+    // eslint-disable-next-line no-alert
+    prompt('Your browser does not support clipboard access. Please copy the text below manually:', text)
+  }
+
+  const copyTarget = document.createElement('textarea')
+
+  copyTarget.value = text
+
+  // @NOTE: the opacity is probably unnecessary since the element will be hidden
+  //  behind the #app container since it has a negative z-index, but I've added
+  //  it for good measure
+  copyTarget.style.opacity = '0'
+  copyTarget.style.zIndex = '-9999'
+  copyTarget.style.position = 'absolute'
+
+  document.body.appendChild(copyTarget)
+
+  copyTarget.focus()
+  copyTarget.setSelectionRange(0, copyTarget.value.length)
+
+  document.execCommand('copy')
+
+  document.body.removeChild(copyTarget)
+
+  EventBus.$emit('toast:success', toastMessage, 5000)
+
+}

--- a/src/views/GalleryView.vue
+++ b/src/views/GalleryView.vue
@@ -1,6 +1,7 @@
 <template>
   <div v-if="gallery">
     <app-header :hide-network-details="true" :title="gallery.name">
+      <b-button variant="outline-primary" @click="copyShareLink" ref="copy-share-link-button">Copy Share Link</b-button>
       <b-button variant="outline-primary" @click="viewFullscreen" v-if="browserSupportsFullscreen">
         View Fullscreen
       </b-button>
@@ -42,6 +43,7 @@
 <script>
 import EventBus from '../util/eventBus'
 import Gallery from '../util/api/gallery'
+import copyToClipboard from '../util/copyToClipboard'
 import fullscreenHelper from '../util/fullscreenHelper'
 
 import AppHeader from '../components/AppHeader'
@@ -78,6 +80,10 @@ export default {
   methods: {
     viewFullscreen() {
       fullscreenHelper.requestFullscreen(this.$refs['carousel-container'])
+    },
+    copyShareLink() {
+      copyToClipboard(window.location.href, 'Share link copied to clipboard!')
+      this.$refs['copy-share-link-button'].focus()
     },
     viewRecord(tokenId) {
       this.$router.push({ name: 'record-detail', params: { recordId: tokenId } })

--- a/src/views/RecordDetailView.vue
+++ b/src/views/RecordDetailView.vue
@@ -11,6 +11,7 @@
             </div>
             <div class="col-12 col-md-7">
               <div>
+
                 <div v-if="codexRecord.metadata">
                   <h1>{{ codexRecord.metadata.name }}</h1>
                   <div class="description">{{ codexRecord.metadata.description }}</div>
@@ -18,18 +19,17 @@
                 <div v-else>
                   <h1>Codex Record #{{ codexRecord.tokenId }}</h1>
                 </div>
-                <a href="#" @click.prevent="toggleShowDetails">Toggle details</a>
-                <record-blockchain-details v-if="showDetails" :codexRecord="codexRecord" />
-                <div class="mt-3 action-buttons" v-if="isOwner">
-                  <b-button class="mr-2" variant="primary" v-b-modal.recordManageModal>
+
+                <div class="owner-action-buttons action-buttons" v-if="isOwner">
+                  <b-button variant="primary" v-b-modal.recordManageModal>
                     Manage
                   </b-button>
 
-                  <b-button class="mr-2" variant="primary" v-b-modal.approveTransferModal>
+                  <b-button variant="primary" v-b-modal.approveTransferModal>
                     Transfer
                   </b-button>
 
-                  <b-button class="mr-2" variant="primary" v-b-modal.recordPrivacySettings>
+                  <b-button variant="primary" v-b-modal.recordPrivacySettings>
                     Settings
                   </b-button>
 
@@ -43,11 +43,19 @@
                   <approve-transfer-modal :codex-record="codexRecord" />
                   <privacy-settings-modal :codex-record="codexRecord" :onUpdated="onSettingsUpdate" />
                 </div>
-                <div class="mt-3" v-if="isApproved">
-                  <b-button @click="acceptTransfer">
-                    Accept Record transfer
+
+                <div class="public-action-buttons action-buttons">
+                  <b-button @click="copyShareLink" ref="copy-share-link-button">Copy Share Link</b-button>
+                  <b-button @click="toggleShowDetails">Toggle Details</b-button>
+                </div>
+
+                <div class="approved-action-buttons action-buttons" v-if="isApproved">
+                  <b-button variant="primary" @click="acceptTransfer">
+                    Accept Transfer
                   </b-button>
                 </div>
+
+                <record-blockchain-details v-if="showDetails" :codexRecord="codexRecord" />
               </div>
             </div>
           </div>
@@ -68,10 +76,10 @@
 
 <script>
 import Record from '../util/api/record'
+import EventBus from '../util/eventBus'
 import { ZeroAddress } from '../util/constants/web3'
 import callContract from '../util/web3/callContract'
-import EventBus from '../util/eventBus'
-
+import copyToClipboard from '../util/copyToClipboard'
 
 import RecordProvenance from '../components/RecordProvenance'
 import RecordManageModal from '../components/modals/RecordManageModal'
@@ -195,6 +203,10 @@ export default {
     setMainImage(uri) {
       this.activeMainImage = uri
     },
+    copyShareLink() {
+      copyToClipboard(window.location.href, 'Share link copied to clipboard!')
+      this.$refs['copy-share-link-button'].focus()
+    },
   },
 }
 </script>
@@ -204,18 +216,19 @@ export default {
 @import "../assets/variables.styl"
 
 .description
+  margin-bottom: 1rem
   white-space: pre-wrap
 
 .action-buttons
   display: flex
-  flex-direction: column
+  flex-wrap: wrap
 
   button
+    margin-right: .5rem
     margin-bottom: 1rem
 
-  @media screen and (min-width: $breakpoint-sm)
-    flex-direction: row
+    @media screen and (max-width: $breakpoint-md)
+      width: 100%
+      margin-right: 0
 
-    button
-      margin-bottom: 1rem
 </style>


### PR DESCRIPTION
Adding the button to RecordDetailView was a bit tricky. Long story short, I changed the "toggle details" text button to a "real" button, and shuffled some stuff around. Check out the screenshots below.

## Owner (Desktop)
![screen shot 2018-07-13 at 5 44 10 pm](https://user-images.githubusercontent.com/2358694/42717804-5561dd9a-86c9-11e8-9a49-9501c8dec654.png)

## Owner (Mobile)
![screen shot 2018-07-13 at 5 44 21 pm](https://user-images.githubusercontent.com/2358694/42717811-6480db78-86c9-11e8-9328-3e856bb3550b.png)

## Logged-out (Desktop)
![screen shot 2018-07-13 at 5 45 01 pm](https://user-images.githubusercontent.com/2358694/42717821-728c6066-86c9-11e8-8bc5-473e96a5d4d4.png)

## Logged-out (Mobile)
![screen shot 2018-07-13 at 5 45 04 pm](https://user-images.githubusercontent.com/2358694/42717828-7b6fd14a-86c9-11e8-9506-5538eb6611c7.png)

## Approved (Desktop)
![screen shot 2018-07-13 at 5 45 33 pm](https://user-images.githubusercontent.com/2358694/42717840-878f6814-86c9-11e8-90bd-9f954e5954e9.png)

## Approved (Mobile)
![screen shot 2018-07-13 at 5 45 37 pm](https://user-images.githubusercontent.com/2358694/42717845-8ed5bce0-86c9-11e8-8add-e1e80b96571b.png)

## Details Toggled Open
![screen shot 2018-07-13 at 5 45 44 pm](https://user-images.githubusercontent.com/2358694/42717857-a036224a-86c9-11e8-8523-85b608b18eb6.png)
