### PR TITLE
Fix for a bug that prevents Record descriptions from being blank

### DIFF
--- a/src/components/modals/CreateRecordModal.vue
+++ b/src/components/modals/CreateRecordModal.vue
@@ -70,13 +70,14 @@
 </template>
 
 <script>
-import { mapState } from 'vuex'
 import debug from 'debug'
-import contractHelper from '../../util/contractHelper'
-import config from '../../util/config'
+import { mapState } from 'vuex'
+
 import File from '../../util/api/file'
 import Record from '../../util/api/record'
 import EventBus from '../../util/eventBus'
+import contractHelper from '../../util/contractHelper'
+import { NullDescriptionHash } from '../../util/constants/web3'
 import additionalDataHelper from '../../util/additionalDataHelper'
 import MetaMaskNotificationModal from './MetaMaskNotificationModal'
 
@@ -189,7 +190,7 @@ export default {
           //
           // metadata.nameHash === soliditySha3(metadata.name)
           // metadata.mainImage.hash === this.uploadedFileHash
-          // metadata.descriptionHash === (metadata.description ? soliditySha3(metadata.description) : config.nullDescriptionHash)
+          // metadata.descriptionHash === (metadata.description ? soliditySha3(metadata.description) : NullDescriptionHash)
 
           return this.createRecord(metadata)
 
@@ -213,7 +214,7 @@ export default {
       const input = [
         account,
         soliditySha3(metadata.name),
-        metadata.description ? soliditySha3(metadata.description) : config.nullDescriptionHash,
+        metadata.description ? soliditySha3(metadata.description) : NullDescriptionHash,
         [this.uploadedFileHash],
         additionalDataHelper.encode([
           process.env.VUE_APP_METADATA_PROVIDER_ID, // providerId

--- a/src/components/modals/RecordManageModal.vue
+++ b/src/components/modals/RecordManageModal.vue
@@ -111,8 +111,9 @@ import 'vue2-dropzone/dist/vue2Dropzone.min.css'
 import File from '../../util/api/file'
 import config from '../../util/config'
 import Record from '../../util/api/record'
-import contractHelper from '../../util/contractHelper'
 import EventBus from '../../util/eventBus'
+import contractHelper from '../../util/contractHelper'
+import { NullDescriptionHash } from '../../util/constants/web3'
 import additionalDataHelper from '../../util/additionalDataHelper'
 import MetaMaskNotificationModal from './MetaMaskNotificationModal'
 
@@ -246,7 +247,7 @@ export default {
       this.nameHash = this.hash(this.name)
     },
     updateDescriptionHash() {
-      this.descriptionHash = this.description ? this.hash(this.description) : config.nullDescriptionHash
+      this.descriptionHash = this.description ? this.hash(this.description) : NullDescriptionHash
     },
     hash(input) {
       return this.instance.utils.soliditySha3(input)

--- a/src/util/config.js
+++ b/src/util/config.js
@@ -31,11 +31,6 @@ const etherScanUrl = (() => {
 
 export default {
 
-  // @TODO: I wasn't really sure where the best place to put this would be,
-  //  remove this comment or move nullDescriptionHash somewhere else after
-  //  receiving Pull Request feedback
-  nullDescriptionHash: `0x${new Array(64).fill(0).join('')}`,
-
   showManageTokensPage: process.env.VUE_APP_TARGET_ENV !== 'production',
   showFaucet: process.env.VUE_APP_TARGET_ENV !== 'production',
   showCreateGiveawayButton: process.env.VUE_APP_TARGET_ENV !== 'production',

--- a/src/util/constants/web3.js
+++ b/src/util/constants/web3.js
@@ -30,10 +30,12 @@ const Web3Errors = {
 }
 
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
+const NullDescriptionHash = `0x${new Array(64).fill(0).join('')}`
 
 export {
-  ExpectedNetworkId,
   Networks,
   Web3Errors,
   ZeroAddress,
+  ExpectedNetworkId,
+  NullDescriptionHash,
 }


### PR DESCRIPTION
When we upgraded web3 to beta 34, null description hashes were broken. Web3 0.2.0 hashed null / blank strings differently than 1.x so I've updated that logic to match what's done on the backend.

I didn't really know where to put a certain application-wide variable, so I left a comment [here](https://github.com/codex-protocol/private-web.codex-viewer/pull/17/files#diff-19ae3cea58dd881db041e62b0b2ba24bR34) about it. I'd like to know where you guys think that should go.